### PR TITLE
Rename endpoint from '/admin/all' to '/admin/games'

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Methode en end-point | return value | omschrijving
 `GET /admin/aggregate` | 200 Ok | Totaal aantal gespeelde spellen en spelers; overzicht van de gekozen api's
 `GET /admin/players` | 200 Ok | Overzicht van gebruikersnamen en email-adressen van alle spelers
 `GET /admin/dates` | 200 Ok | Totaal van het aantal gespeelde spelletjes per dag
-`GET /admin/all` | 200 Ok | Overzicht van alle gespeelde spelletjes
+`GET /admin/games` | 200 Ok | Overzicht van alle gespeelde spelletjes
 
 ## Logging
 


### PR DESCRIPTION
De readme aangepast om de incorrecte documentatie voor het admin endpoint `admin/all` te fixen.
Het juiste endpoint is `admin/games`